### PR TITLE
ci(reusable-workflows/gradle-build): enhancement reusable Gradle Build workflow

### DIFF
--- a/.github/workflows/reusable-gradle-build.yml
+++ b/.github/workflows/reusable-gradle-build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3.13.0
         with:
-          java-version: ${{ github.event.inputs.java-version }}
+          java-version: ${{ inputs.java-version }}
           distribution: zulu
 
       - name: Validate Gradle Wrapper
@@ -56,10 +56,10 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew ${{ github.event.inputs.build-args }}
+        run: ./gradlew ${{ inputs.build-args }}
 
       - name: Upload build artifacts
-        if: ${{ github.event.inputs.upload-artifacts }}
+        if: ${{ inputs.upload-artifacts }}
         uses: actions/upload-artifact@v3.1.3
         with:
           name: build-artifacts

--- a/.github/workflows/reusable-gradle-build.yml
+++ b/.github/workflows/reusable-gradle-build.yml
@@ -17,6 +17,11 @@ on:
         type: boolean
         default: true
 
+      cache-read-only:
+        required: false
+        type: boolean
+        default: ${{ github.event.repository != null && github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -36,6 +41,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.9.0
         with:
+          cache-read-only: ${{ inputs.cache-read-only }}
           gradle-home-cache-cleanup: true
           gradle-home-cache-includes: |
             caches


### PR DESCRIPTION
This PR introduces enhancements to the reusable Gradle build workflow. It adds a new input parameter 'cache-read-only' and fixes the input expressions for existing parameters. The 'cache-read-only' parameter is used to control the cache behavior of the Gradle build action.
